### PR TITLE
Fix the version of vcpkg

### DIFF
--- a/synergy-vcpkg/centos/7.6/Dockerfile
+++ b/synergy-vcpkg/centos/7.6/Dockerfile
@@ -28,7 +28,7 @@ ENV PATH=/opt/rh/devtoolset-9/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/s
 ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/centos/8/Dockerfile
+++ b/synergy-vcpkg/centos/8/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH=/opt/rh/gcc-toolset-10/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-10/root/usr/lib64:/opt/rh/gcc-toolset-10/root/usr/lib:/opt/rh/gcc-toolset-10/root/usr/lib64/dyninst:/opt/rh/gcc-toolset-10/root/usr/lib/dyninst
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1  --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/debian/10/Dockerfile
+++ b/synergy-vcpkg/debian/10/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/debian/11/Dockerfile
+++ b/synergy-vcpkg/debian/11/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/debian/9/Dockerfile
+++ b/synergy-vcpkg/debian/9/Dockerfile
@@ -31,7 +31,7 @@ RUN sed -i 's/ stretch / buster /g' /etc/apt/sources.list \
     && rm -rf /var/lib/apt/lists
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/fedora/33/Dockerfile
+++ b/synergy-vcpkg/fedora/33/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf -y update \
     && rm -rf /var/cache/dnf
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/fedora/34/Dockerfile
+++ b/synergy-vcpkg/fedora/34/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf -y update \
     && rm -rf /var/cache/dnf
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/ubuntu/18.04/Dockerfile
+++ b/synergy-vcpkg/ubuntu/18.04/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/ubuntu/20.04/Dockerfile
+++ b/synergy-vcpkg/ubuntu/20.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \

--- a/synergy-vcpkg/ubuntu/21.04/Dockerfile
+++ b/synergy-vcpkg/ubuntu/21.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists
 
 # Setup vcpkg
-RUN git clone --depth=1 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
+RUN git clone --depth=1 --branch 2021.05.12 https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT \
     && $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh \
     && $VCPKG_INSTALLATION_ROOT/vcpkg integrate install \
     && chmod 0777 -R $VCPKG_INSTALLATION_ROOT \


### PR DESCRIPTION
This fixes the version of VCPKG to 2021.05.12. This prevents the churn of the VCPKG project from affecting our images.